### PR TITLE
seat Create Delete 구현

### DIFF
--- a/src/main/java/org/example/ticketingdemo/domain/seat/controller/SeatController.java
+++ b/src/main/java/org/example/ticketingdemo/domain/seat/controller/SeatController.java
@@ -1,0 +1,36 @@
+package org.example.ticketingdemo.domain.seat.controller;
+import lombok.RequiredArgsConstructor;
+import org.example.ticketingdemo.common.dto.response.ApiResponse;
+import org.example.ticketingdemo.domain.seat.dto.request.SeatBuyRequest;
+import org.example.ticketingdemo.domain.seat.dto.response.SeatBuyResponse;
+import org.example.ticketingdemo.domain.seat.service.SeatInternalService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/seats")
+@RequiredArgsConstructor
+public class SeatController {
+
+    private final SeatInternalService seatInternalService;
+
+    @PostMapping("/buy/{concertId}")
+    public ResponseEntity<ApiResponse<SeatBuyResponse>> buySeat(
+            @PathVariable Long concertId,
+            @RequestParam Long userId, // 수정 사항
+            @RequestBody SeatBuyRequest seatBuyRequest
+    ) {
+        SeatBuyResponse response = seatInternalService.buySeat(seatBuyRequest, userId, concertId);
+        return ApiResponse.ok(response);
+    }
+
+
+    @PostMapping("/cancel/{seatId}")
+    public ResponseEntity<ApiResponse<SeatBuyResponse>> cancelSeat(
+            @PathVariable Long seatId,
+            @RequestParam Long userId // 수정 사항
+    ) {
+        SeatBuyResponse response = seatInternalService.cancelSeat(seatId, userId);
+        return ApiResponse.ok(response);
+    }
+}

--- a/src/main/java/org/example/ticketingdemo/domain/seat/dto/request/SeatBuyRequest.java
+++ b/src/main/java/org/example/ticketingdemo/domain/seat/dto/request/SeatBuyRequest.java
@@ -1,0 +1,6 @@
+package org.example.ticketingdemo.domain.seat.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record SeatBuyRequest(
+        @NotBlank String seatNumber) {}

--- a/src/main/java/org/example/ticketingdemo/domain/seat/dto/response/SeatBuyResponse.java
+++ b/src/main/java/org/example/ticketingdemo/domain/seat/dto/response/SeatBuyResponse.java
@@ -1,0 +1,19 @@
+package org.example.ticketingdemo.domain.seat.dto.response;
+
+import org.example.ticketingdemo.domain.seat.entity.Seat;
+
+import java.time.LocalDateTime;
+
+public record SeatBuyResponse (
+        String seatNumber,
+        SeatUserResponse user,
+        LocalDateTime createAt
+){
+    public static SeatBuyResponse from(Seat seat, SeatUserResponse seatUserResponse){
+        return new SeatBuyResponse(
+                seat.getSeatNumber(),
+                seatUserResponse,
+                LocalDateTime.now()
+        );
+    }
+}

--- a/src/main/java/org/example/ticketingdemo/domain/seat/dto/response/SeatCreateResponse.java
+++ b/src/main/java/org/example/ticketingdemo/domain/seat/dto/response/SeatCreateResponse.java
@@ -1,0 +1,19 @@
+package org.example.ticketingdemo.domain.seat.dto.response;
+
+import org.example.ticketingdemo.domain.seat.entity.Seat;
+
+import java.time.LocalDateTime;
+
+public record SeatCreateResponse (
+        String seatNumber,
+        SeatUserResponse user,
+        LocalDateTime createAt
+){
+    public static SeatCreateResponse from(Seat seat, SeatUserResponse seatUserResponse){
+        return new SeatCreateResponse(
+                seat.getSeatNumber(),
+                seatUserResponse,
+                LocalDateTime.now()
+        );
+    }
+}

--- a/src/main/java/org/example/ticketingdemo/domain/seat/dto/response/SeatUserResponse.java
+++ b/src/main/java/org/example/ticketingdemo/domain/seat/dto/response/SeatUserResponse.java
@@ -1,0 +1,16 @@
+package org.example.ticketingdemo.domain.seat.dto.response;
+
+import org.example.ticketingdemo.domain.seat.entity.Seat;
+
+// 유저의 정보는 이름과 이메일만
+public record SeatUserResponse(
+        String userName,
+        String email){
+
+    public static SeatUserResponse from(Seat seat){
+        return new SeatUserResponse(
+                seat.getUser().getUserName(),
+                seat.getUser().getEmail()
+        );
+    }
+}

--- a/src/main/java/org/example/ticketingdemo/domain/seat/entity/Seat.java
+++ b/src/main/java/org/example/ticketingdemo/domain/seat/entity/Seat.java
@@ -1,0 +1,53 @@
+package org.example.ticketingdemo.domain.seat.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.ticketingdemo.common.entity.BaseEntity;
+import org.example.ticketingdemo.domain.seat.enums.SeatStatus;
+import org.example.ticketingdemo.domain.user.entity.User;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "seat")
+public class Seat extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY) // auto-increment
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    // 콘서트
+    /*@ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "concert_id")
+    private Concert concert;
+    */
+
+    @Enumerated(EnumType.STRING)
+    private SeatStatus status;
+
+    private String seatNumber;
+
+    private Seat(/*Concert concert */ SeatStatus status, String seatNumber) {
+        this.user = user;
+        // this.concert = concert
+        this.status = SeatStatus.AVAILABLE; // concert에서 만들어질때(구매되기 전)
+        this.seatNumber = seatNumber;
+    }
+
+    public void changeStatus(SeatStatus status){
+        this.status = status;
+    }
+
+    public void assignUser(User user) {
+        this.user = user;
+    }
+
+    public static Seat create(/*Concert concert */SeatStatus status, String seatNumber) {
+        return new Seat(/*concert */ status, seatNumber);
+    }
+}

--- a/src/main/java/org/example/ticketingdemo/domain/seat/enums/SeatStatus.java
+++ b/src/main/java/org/example/ticketingdemo/domain/seat/enums/SeatStatus.java
@@ -1,0 +1,6 @@
+package org.example.ticketingdemo.domain.seat.enums;
+
+public enum SeatStatus {
+    AVAILABLE, // 구매 가능
+    SOLD       // 판매 완료
+}

--- a/src/main/java/org/example/ticketingdemo/domain/seat/exception/InvaildSeatException.java
+++ b/src/main/java/org/example/ticketingdemo/domain/seat/exception/InvaildSeatException.java
@@ -1,0 +1,9 @@
+package org.example.ticketingdemo.domain.seat.exception;
+
+import org.example.ticketingdemo.common.exception.GlobalException;
+
+public class InvaildSeatException extends GlobalException {
+    public InvaildSeatException(SeatErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/org/example/ticketingdemo/domain/seat/exception/SeatErrorCode.java
+++ b/src/main/java/org/example/ticketingdemo/domain/seat/exception/SeatErrorCode.java
@@ -1,0 +1,22 @@
+package org.example.ticketingdemo.domain.seat.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.example.ticketingdemo.common.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SeatErrorCode implements ErrorCode {
+
+    SEAT_NOT_FOUND_USER_ID("SEAT_001", HttpStatus.NOT_FOUND, "User를 찾을 수 없습니다."),
+    SEAT_NOT_FOUND_SEAT("SEAT_002", HttpStatus.NOT_FOUND, "Seat를 찾을 수 없습니다."),
+    SEAT_ALREADY_SOLD("SEAT_003", HttpStatus.BAD_REQUEST, "이미 판매된 좌석입니다."),
+    SEAT_NOT_SOLD("SEAT_004", HttpStatus.BAD_REQUEST, "판매되지 않은 좌석은 취소할 수 없습니다."),
+    SEAT_NOT_MATCH_USER("SEAT_005", HttpStatus.FORBIDDEN, "해당 좌석은 이 유저가 구매한 좌석이 아닙니다.");
+
+    private final String code;
+    private final HttpStatus httpStatus;
+    private final String message;
+}
+

--- a/src/main/java/org/example/ticketingdemo/domain/seat/repository/SeatRepository.java
+++ b/src/main/java/org/example/ticketingdemo/domain/seat/repository/SeatRepository.java
@@ -1,0 +1,12 @@
+package org.example.ticketingdemo.domain.seat.repository;
+
+import org.example.ticketingdemo.domain.seat.entity.Seat;
+import org.example.ticketingdemo.domain.seat.enums.SeatStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface SeatRepository extends JpaRepository<Seat,Long> {
+    Optional<Seat> findBySeatNumber(String seatNumber);
+}

--- a/src/main/java/org/example/ticketingdemo/domain/seat/service/SeatExternalService.java
+++ b/src/main/java/org/example/ticketingdemo/domain/seat/service/SeatExternalService.java
@@ -1,0 +1,25 @@
+package org.example.ticketingdemo.domain.seat.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.ticketingdemo.domain.seat.entity.Seat;
+import org.example.ticketingdemo.domain.seat.exception.InvaildSeatException;
+import org.example.ticketingdemo.domain.seat.exception.SeatErrorCode;
+import org.example.ticketingdemo.domain.seat.repository.SeatRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SeatExternalService  {
+    private final SeatRepository seatRepository;
+
+    @Transactional // concert에서 seat 생성할 때
+    public Seat createSeat(Seat seat) {
+        return seatRepository.save(seat);
+    }
+
+    @Transactional
+    public Seat getCommentById(Long seatId) {
+        return seatRepository.findById(seatId).orElseThrow(()-> new InvaildSeatException(SeatErrorCode.SEAT_NOT_FOUND_SEAT));
+    }
+}

--- a/src/main/java/org/example/ticketingdemo/domain/seat/service/SeatInternalService.java
+++ b/src/main/java/org/example/ticketingdemo/domain/seat/service/SeatInternalService.java
@@ -1,0 +1,68 @@
+package org.example.ticketingdemo.domain.seat.service;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.example.ticketingdemo.domain.seat.dto.request.SeatBuyRequest;
+import org.example.ticketingdemo.domain.seat.dto.response.SeatBuyResponse;
+
+import org.example.ticketingdemo.domain.seat.dto.response.SeatUserResponse;
+import org.example.ticketingdemo.domain.seat.entity.Seat;
+import org.example.ticketingdemo.domain.seat.enums.SeatStatus;
+import org.example.ticketingdemo.domain.seat.exception.InvaildSeatException;
+import org.example.ticketingdemo.domain.seat.exception.SeatErrorCode;
+import org.example.ticketingdemo.domain.seat.repository.SeatRepository;
+import org.example.ticketingdemo.domain.user.entity.User;
+import org.example.ticketingdemo.domain.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class SeatInternalService {
+    private final SeatRepository seatRepository;
+    private final UserRepository userRepository;
+    // private final ConcertRepository concertRepository;
+
+    @Transactional // Buy
+    public SeatBuyResponse buySeat(SeatBuyRequest seatBuyRequest, Long userId, Long concertId) {
+        // 유저 조회
+        User user = userRepository.findById(userId).orElseThrow(() -> new InvaildSeatException(SeatErrorCode.SEAT_NOT_FOUND_USER_ID));
+
+        // Concert에서 생성된 좌석 조회
+        Seat seat = seatRepository.findBySeatNumber(seatBuyRequest.seatNumber()).orElseThrow(() -> new InvaildSeatException(SeatErrorCode.SEAT_NOT_FOUND_SEAT));
+
+        // 이미 팛린 좌석인지 확인
+        if(seat.getStatus() == SeatStatus.SOLD) {
+            throw new InvaildSeatException(SeatErrorCode.SEAT_ALREADY_SOLD);
+        }
+        seat.assignUser(user); // 유저와 연결
+        seat.changeStatus(SeatStatus.SOLD); // 구매 되어 seat 상태 sold 변경
+        return SeatBuyResponse.from(seat, SeatUserResponse.from(seat));
+    }
+    @Transactional
+    public SeatBuyResponse cancelSeat(Long seatId, Long userId) {
+        // 유저 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new InvaildSeatException(SeatErrorCode.SEAT_NOT_FOUND_USER_ID));
+
+        // 좌석 조회
+        Seat seat = seatRepository.findById(seatId)
+                .orElseThrow(() -> new InvaildSeatException(SeatErrorCode.SEAT_NOT_FOUND_USER_ID));
+
+        // 이미 판매되지 않았다면 취소 불가
+        if (seat.getStatus() != SeatStatus.SOLD) {
+            throw new InvaildSeatException(SeatErrorCode.SEAT_NOT_SOLD);
+        }
+
+        // 좌석 구매자가 본인인지 확인
+        if (!seat.getUser().getId().equals(user.getId())) {
+            throw new InvaildSeatException(SeatErrorCode.SEAT_NOT_MATCH_USER);
+        }
+
+        // 취소 처리
+        seat.assignUser(null);
+        seat.changeStatus(SeatStatus.AVAILABLE);
+
+        return SeatBuyResponse.from(seat, null);
+    }
+}


### PR DESCRIPTION
**개발** 
현재 seat의 
Create(이 부분은 SeatExternalService에 제작했으니 이를 통해서 concert하시는 분이 이용하시면 좋을 것 같습니다.
Buy
Cancle
부분의 service와 controller를 제작했습니다.

**추가 개발 일정**
concert가 개발된다면 팔리지 않은 seat를 조회하는 기능을 추가할 생각입니다. 
